### PR TITLE
Traceability improvements

### DIFF
--- a/Baubit.Test/Traceability/Errors/CompositeError/Test.cs
+++ b/Baubit.Test/Traceability/Errors/CompositeError/Test.cs
@@ -1,12 +1,24 @@
-﻿namespace Baubit.Test.Traceability.Errors.CompositeError
+﻿using Baubit.Traceability;
+using Baubit.Traceability.Reasons;
+using FluentResults;
+
+namespace Baubit.Test.Traceability.Errors.CompositeError
 {
     public class Test
     {
         [Fact]
         public void CompositeErrorCanBeStringified()
         {
-            var compositeError = new Baubit.Traceability.Errors.CompositeError<string>();
-            Assert.False(string.IsNullOrEmpty(compositeError.ToString()));
+            var result = Result.Try(() => { throw new Exception(""); return 0; });
+            var errorString = result.WithReason(new MyReason()).CaptureAsError().ToString();
+            Assert.False(string.IsNullOrEmpty(errorString));
+        }
+    }
+
+    public class MyReason : AReason
+    {
+        public MyReason() : base("Some specific reason", default)
+        {
         }
     }
 }

--- a/Baubit/Traceability/Errors/CompositeError.cs
+++ b/Baubit/Traceability/Errors/CompositeError.cs
@@ -25,16 +25,29 @@ namespace Baubit.Traceability.Errors
         {
             StringBuilder stringBuilder = new StringBuilder();
             stringBuilder.AppendLine(Message);
-            stringBuilder.AppendLine("Reasons(non-error):");
-            for (int i = 0; i < NonErrorReasons?.Count; i++)
+            stringBuilder.AppendLine("".PadRight(10,'-'));
+            if (Reasons.Count > 0 || NonErrorReasons.Count > 0)
             {
-                stringBuilder.AppendLine($"{i + 1}. {NonErrorReasons[i].ToString()}");
+                if (Reasons.Count > 0)
+                {
+                    stringBuilder.AppendLine("Reasons(errors):");
+                    stringBuilder.AppendJoin(Environment.NewLine, Reasons.Select((error, i) => $"{i + 1}. {error.ToString()}"));
+                    stringBuilder.AppendLine();
+                }
+                var reportableNonErrors = NonErrorReasons.Where(reason => !Reasons.Contains(reason));
+                if (reportableNonErrors.Any())
+                {
+                    stringBuilder.AppendLine("".PadRight(10, '-'));
+                    stringBuilder.AppendLine("Reasons(non-error):");
+                    stringBuilder.AppendJoin(Environment.NewLine, reportableNonErrors.Select((nonError, i) => $"{i + 1}. {nonError.ToString()}"));
+                    stringBuilder.AppendLine();
+                }
             }
-            stringBuilder.AppendLine("Reasons(errors):");
-            for (int i = 0; i < Reasons?.Count; i++)
+            else
             {
-                stringBuilder.AppendLine($"{i + 1}. {Reasons[i].ToString()}");
+                stringBuilder.AppendLine("Details unavailable");
             }
+            stringBuilder.AppendLine("".PadRight(10, '-'));
             return stringBuilder.ToString();
         }
     }

--- a/Baubit/Traceability/TraceabilityExtensions.cs
+++ b/Baubit/Traceability/TraceabilityExtensions.cs
@@ -1,4 +1,5 @@
-﻿using FluentResults;
+﻿using Baubit.Traceability.Errors;
+using FluentResults;
 
 namespace Baubit.Traceability
 {
@@ -13,6 +14,11 @@ namespace Baubit.Traceability
                     disposables[i].Dispose();
                 }
             });
+        }
+
+        public static CompositeError<T> CaptureAsError<T>(this Result<T> result)
+        {
+            return new CompositeError<T>(result);
         }
     }
 }


### PR DESCRIPTION
1) Improved stringification of the CompositeError<T>
2) CaptureAsError - Extension method on Result<T> to build a CompositeError<T> for further processing